### PR TITLE
Add ADDC conference

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -512,6 +512,18 @@
       "city": "Boston",
       "callforpaper": true,
       "emojiflag": "🇺🇸"
+    },
+    {
+      "title": "ADDC",
+      "year": 2018,
+      "startdate": "2018/07/04",
+      "enddate": "2018/07/06",
+      "where": "Avinguda Diagonal, 547, 08029 Barcelona, Spain",
+      "homepage": "http://www.addconf.com",
+      "country": "Spain",
+      "city": "Barcelona",
+      "callforpaper": true,
+      "emojiflag": "🇪🇸"
     }
   ]
 }


### PR DESCRIPTION
- **Conference Name**: ADDC
- **Conference URL**: https://addconf.com
- **Why it should be added to `awesome-mobile-conferences`**:
- [x] Conference has a website
- [x] Conference has start/end date (if one day only conference write the same date)
- [x] Check address using [Geocoder](https://google-developers.appspot.com/maps/documentation/utils/geocoder/) to get clean address
- [x] Updated **contents.json** instead of README
- [x] Is the conference at the bottom of the array?
