### PR TITLE
Fix typo in App Builders

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -118,7 +118,7 @@
       "emojiflag": "🇨🇭"
     },
     {
-      "title": "App Builder 2018",
+      "title": "App Builders 2018",
       "year": 2018,
       "startdate": "2018/04/16",
       "enddate": "2018/04/17",


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-mobile-conferences 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Conference Name**: App Builders
- **Conference URL**: https://www.appbuilders.ch
- **Why it should be added to `awesome-mobile-conferences`**:
- [x] Conference has a website
- [x] Conference has start/end date (if one day only conference write the same date)
- [x] Check address using [Geocoder](https://google-developers.appspot.com/maps/documentation/utils/geocoder/) to get clean address
- [x] Updated **contents.json** instead of README
- [ ] Is the conference at the bottom of the array?