### PR TITLE
add codemobile conference

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -548,6 +548,18 @@
       "city": "Aberystwyth",
       "callforpaper": false,
       "emojiflag": "🇬🇧"
+    },
+    {
+      "title": "Codemobile",
+      "year": 2018,
+      "startdate": "2018/04/02",
+      "enddate": "2018/04/05",
+      "where": "University of Chester, Parkgate Road, Chester, UK",
+      "homepage": "http://www.codemobile.co.uk/",
+      "country": "United Kingdom",
+      "city": "Chester",
+      "callforpaper": false,
+      "emojiflag": "🇬🇧"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-mobile-conferences 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Conference Name**: Codemobile
- **Conference URL**: http://www.codemobile.co.uk/
- **Why it should be added to `awesome-mobile-conferences`**: It's a mobile conference
- [x] Conference has a website
- [x] Conference has start/end date (if one day only conference write the same date)
- [x] Check address using [Geocoder](https://google-developers.appspot.com/maps/documentation/utils/geocoder/) to get clean address
- [x] Updated **contents.json** instead of README
- [x] Is the conference at the bottom of the array?
