### PR TITLE
Add AM and droidcon berlin

### DIFF
--- a/contents.json
+++ b/contents.json
@@ -584,6 +584,30 @@
       "city": "San Francisco",
       "callforpaper": false,
       "emojiflag": "🇺🇸"
+    },
+    {
+      "title": "Android Makers FR",
+      "year": 2017,
+      "startdate": "2017/04/10",
+      "enddate": "2017/04/11",
+      "where": "Les salons de l'Aveyron 17 Rue de l'Aubrac, Paris",
+      "homepage": "http://androidmakers.fr/",
+      "country": "France",
+      "city": "Paris",
+      "callforpaper": false,
+      "emojiflag": "🇫🇷"
+    },
+    {
+      "title": "droidcon Berlin",
+      "year": 2017,
+      "startdate": "2017/09/03",
+      "enddate": "2017/09/05",
+      "where": "CityCube, Berlin",
+      "homepage": "http://droidcon.de/",
+      "country": "Germany",
+      "city": "Berlin",
+      "callforpaper": false,
+      "emojiflag": "🇩🇪"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-mobile-conferences 😊 -->

<!-- Reminder: Please update contents.json instead of the README -->

<!-- Please fill out the short form below -->

- **Conference Name**:
- **Conference URL**:
- **Why it should be added to `awesome-mobile-conferences`**:
- [ ] Conference has a website
- [ ] Conference has start/end date (if one day only conference write the same date)
- [ ] Check address using [Geocoder](https://google-developers.appspot.com/maps/documentation/utils/geocoder/) to get clean address
- [ ] Updated **contents.json** instead of README
- [ ] Is the conference at the bottom of the array?
